### PR TITLE
📝: rnSpoilerTagをv2023.9.0に更新

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -22,7 +22,7 @@ const copyright = `<div class="no-content">
 
 const injectOptions = {
   organization,
-  rnSpoilerTag: 'master',
+  rnSpoilerTag: 'v2023.9.0',
 };
 
 module.exports = {


### PR DESCRIPTION
## ✅ What's done

- rnSpoilerTagをmasterからv2023.9.0に変更（固定）
  - masterのままだとrn-spoilerにmergeしたものが即座に使用されてしまい、ドキュメントと不整合になるため

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Other (messages to reviewers, concerns, etc.)
### 関連PR(ws-4020側)
- https://github.com/ws-4020/mobile-app-crib-notes/pull/1273
  - このPRのcommitをそのまま持ってきました