### PR TITLE
🚀: Publish 2024.12

### DIFF
--- a/website/docs/react-native/learn/getting-started/create-project.md
+++ b/website/docs/react-native/learn/getting-started/create-project.md
@@ -21,26 +21,17 @@ title: プロジェクトの作成
 :::
 
 ```bash
-npx react-native@0.75.4 init --npm --template https://github.com/ws-4020/rn-spoiler#{@inject: rnSpoilerTag} <YourAppName>
+npx @react-native-community/cli init --pm npm --template https://github.com/ws-4020/rn-spoiler#{@inject: rnSpoilerTag} <YourAppName>
 ```
 
 RN Spoilerは、Expoの[テンプレート](https://github.com/expo/expo/tree/master/templates)をベースにしているので、このあとの[アプリの実行](./launch-created-app.mdx)で紹介しているExpo Goで動作します。
 
 :::info
-[npm](https://www.npmjs.com/)ではなく[Yarn](https://yarnpkg.com/)を利用したい場合は、`--npm`というオプションを削除してください。Yarnがインストールされている場合は、Yarnを利用してパッケージがインストールされます。
-
-```bash
-npx react-native@0.75.4 init --template https://github.com/ws-4020/rn-spoiler#{@inject: rnSpoilerTag} <YourAppName>
-```
-
-:::
-
-:::info
-初めて`npx react-native@0.75.4 init ...`を実行すると、次のように不足しているパッケージをインストールするかと聞かれます。`react-native`をインストールしようとしていれば問題ないので、エンターキーを押して実行してください。
+初めて`npx @react-native-community/cli init ...`を実行すると、次のように不足しているパッケージをインストールするかと聞かれます。`@react-native-community/cli`をインストールしようとしていれば問題ないので、エンターキーを押して実行してください。
 
 ```console
 Need to install the following packages:
-  react-native
+  @react-native-community/cli
 Ok to proceed? (y)
 ```
 


### PR DESCRIPTION
## ✅ What's done

- 📝: deprecatedな npx react-native コマンドを npx @react-native-community/cli に変更
   - URL: https://fintan-contents.github.io/mobile-app-crib-notes/react-native/learn/getting-started/create-project/
   - 理由: 2024/12/31 で 動作が変わり動かなくなる予定のため

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Tests

- [x] lintを実行しての静的チェック
- [x] 確認用ページで見た目に問題ないこと
   - https://ws-4020.github.io/mobile-app-crib-notes/react-native/learn/getting-started/create-project/
- [x] 軽微な修正のため出荷審査省略

## Other (messages to reviewers, concerns, etc.)
### このPRに含まれる修正の元PR
- https://github.com/ws-4020/mobile-app-crib-notes/pull/1332

### 変更対象ページ
* [プロジェクトの作成 | Fintan » Mobile App Development](https://fintan-contents.github.io/mobile-app-crib-notes/react-native/learn/getting-started/create-project/)

### 関連PR
- https://github.com/Fintan-contents/mobile-app-crib-notes/pull/49